### PR TITLE
Carousel bugfix

### DIFF
--- a/__tests__/client/components/ThumbnailCarousel.test.jsx
+++ b/__tests__/client/components/ThumbnailCarousel.test.jsx
@@ -28,6 +28,7 @@ describe('ThumbnailCarousel', () => {
       <ThumbnailCarousel
         images={sampleImages}
         onClickHandler={onThumbnailClick}
+        currentImage={sampleImages[0]}
       />
     );
     expect(thumbnailCarousel.is('.thumbnail-carousel-container')).toBe(true);
@@ -38,6 +39,7 @@ describe('ThumbnailCarousel', () => {
       <ThumbnailCarousel
         images={sampleImages}
         onClickHandler={onThumbnailClick}
+        currentImage={sampleImages[0]}
       />
     );
     
@@ -49,6 +51,7 @@ describe('ThumbnailCarousel', () => {
       <ThumbnailCarousel
         images={sampleImages}
         onClickHandler={onThumbnailClick}
+        currentImage={sampleImages[0]}
       />
     );
     
@@ -61,6 +64,7 @@ describe('ThumbnailCarousel', () => {
       <ThumbnailCarousel
         images={sampleImages}
         onClickHandler={onThumbnailClick}
+        currentImage={sampleImages[0]}
       />
     );
     
@@ -84,6 +88,7 @@ describe('ThumbnailCarousel', () => {
       <ThumbnailCarousel
         images={sampleImages}
         onClickHandler={onThumbnailClick}
+        currentImage={sampleImages[0]}
       />
     );
     

--- a/client/src/components/Gallery.jsx
+++ b/client/src/components/Gallery.jsx
@@ -87,6 +87,7 @@ const Gallery = (props) => {
           setShowModal={setShowModal}
         />
         <ThumbnailCarousel
+          currentImage={state.currentMainView}
           images={images}
           onClickHandler={onThumbnailClick}
         />

--- a/client/src/components/MainView.jsx
+++ b/client/src/components/MainView.jsx
@@ -46,7 +46,7 @@ const MainView = (props) => {
                 key={counter++}
                 counter={counter}
                 image={image}
-                display="inline-block"
+                display="main-image-visible"
                 onClickHandler={onClickToShowModal}
               />
             );
@@ -56,7 +56,7 @@ const MainView = (props) => {
                 key={counter++}
                 counter={counter}
                 image={image}
-                display="none"
+                display=""
               />
             );
           }

--- a/client/src/components/MainViewImage.jsx
+++ b/client/src/components/MainViewImage.jsx
@@ -13,12 +13,7 @@ const MainViewImage = (props) => {
   return (
     <img
       id={`main${counter}`}
-      className="main-image"
-      style={{
-        display,
-        width: 'auto',
-        height: 'auto',
-      }}
+      className={`main-image ${display}`}
       alt="product"
       src={image.full}
       onClick={onClickHandler}

--- a/client/src/components/Modal.jsx
+++ b/client/src/components/Modal.jsx
@@ -76,7 +76,11 @@ const Modal = (props) => {
           currentImage={currentImage}
           setCurrentImage={setCurrentImage}
         />
-        <ModalThumbnailCarousel images={images} onClickHandler={selectImage} />
+        <ModalThumbnailCarousel
+          images={images}
+          onClickHandler={selectImage}
+          currentImage={currentImage}
+        />
       </div>
     </div>
   );

--- a/client/src/components/ModalThumbnailCarousel.jsx
+++ b/client/src/components/ModalThumbnailCarousel.jsx
@@ -4,27 +4,29 @@ import PropTypes from 'prop-types';
 import ModalThumbnailCarouselItem from './ModalThumbnailCarouselItem';
 
 const ModalThumbnailCarousel = (props) => {
-  const { images, onClickHandler } = props;
+  const { images, onClickHandler, currentImage } = props;
 
   return (
     <div className="modal-thumbnail-carousel flex-container">
       <ul className="modal-thumbnail-list flex-container">
         {images.map((image, key) => {
-          let size;
+          let classes;
           if ((key % 3) === 0) {
-            size = 'thumb-lg';
+            classes = 'thumb-lg';
           } else if ((key % 3) === 1) {
-            size = 'thumb-sm thumb-l';
+            classes = 'thumb-sm thumb-l';
+          } else {
+            classes = 'thumb-sm thumb-r';
           }
-          else {
-            size = 'thumb-sm thumb-r';
+          if (image === currentImage) {
+            classes += ' thumb-current';
           }
 
           return (
             <ModalThumbnailCarouselItem
               key={`tn-${key}`}
               id={key}
-              sizeClass={size}
+              sizeClass={classes}
               image={image}
               onClickHandler={onClickHandler}
             />

--- a/client/src/components/ModalThumbnailCarouselItem.jsx
+++ b/client/src/components/ModalThumbnailCarouselItem.jsx
@@ -14,7 +14,7 @@ const ModalThumbnailCarouselItem = (props) => {
     <li>
       <img
         id={`thumbnail-${id}`}
-        className={`round-corners ${sizeClass}`}
+        className={`round-corners modal-thumb-item ${sizeClass}`}
         src={image.small}
         alt="Product Thumbnail"
         onClick={onClickHandler}

--- a/client/src/components/ThumbnailCarousel.jsx
+++ b/client/src/components/ThumbnailCarousel.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import ThumbnailList from './ThumbnailList';
 
 const ThumbnailCarousel = (props) => {
-  const { images, onClickHandler } = props;
+  const { images, onClickHandler, currentImage } = props;
   const firstImageId = 'thumbnail-0';
   const lastImageId = `thumbnail-${images.length - 1}`;
 
@@ -29,6 +29,7 @@ const ThumbnailCarousel = (props) => {
       />
       <ThumbnailList
         images={images}
+        currentImage={currentImage}
         onClickHandler={onClickHandler}
       />
       <div

--- a/client/src/components/ThumbnailCarousel.jsx
+++ b/client/src/components/ThumbnailCarousel.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
 import React from 'react';
 import PropTypes from 'prop-types';
 import ThumbnailList from './ThumbnailList';
@@ -18,6 +19,15 @@ const ThumbnailCarousel = (props) => {
     }
   };
 
+  const onScrollDivClick = (event) => {
+    const { target } = event;
+    const originalStyle = target.style.display;
+
+    target.style.display = 'none';
+    document.elementFromPoint(event.clientX, event.clientY).click();
+    target.style.display = originalStyle;
+  };
+
   return (
     <div
       className="thumbnail-carousel-container flex-container"
@@ -26,6 +36,8 @@ const ThumbnailCarousel = (props) => {
         className="thumbnail-scroll-up"
         onMouseOver={() => onMouseOverHandler('up')}
         onFocus={() => onMouseOverHandler('up')}
+        onClick={onScrollDivClick}
+        onKeyPress={onScrollDivClick}
       />
       <ThumbnailList
         images={images}
@@ -36,6 +48,8 @@ const ThumbnailCarousel = (props) => {
         className="thumbnail-scroll-down"
         onMouseOver={() => onMouseOverHandler('down')}
         onFocus={() => onMouseOverHandler('down')}
+        onClick={onScrollDivClick}
+        onKeyPress={onScrollDivClick}
       />
     </div>
   );
@@ -44,6 +58,7 @@ const ThumbnailCarousel = (props) => {
 ThumbnailCarousel.propTypes = {
   images: PropTypes.arrayOf(PropTypes.object).isRequired,
   onClickHandler: PropTypes.func.isRequired,
+  currentImage: PropTypes.objectOf(PropTypes.string).isRequired,
 };
 
 export default ThumbnailCarousel;

--- a/client/src/components/ThumbnailList.jsx
+++ b/client/src/components/ThumbnailList.jsx
@@ -37,6 +37,7 @@ const ThumbnailList = (props) => {
 ThumbnailList.propTypes = {
   images: PropTypes.arrayOf(PropTypes.object).isRequired,
   onClickHandler: PropTypes.func.isRequired,
+  currentImage: PropTypes.objectOf(PropTypes.string).isRequired,
 };
 
 export default ThumbnailList;

--- a/client/src/components/ThumbnailList.jsx
+++ b/client/src/components/ThumbnailList.jsx
@@ -4,18 +4,32 @@ import PropTypes from 'prop-types';
 import ThumbnailListItem from './ThumbnailListItem';
 
 const ThumbnailList = (props) => {
-  const { images, onClickHandler } = props;
+  const { images, onClickHandler, currentImage } = props;
 
   return (
     <ul className="thumbnail-list flex-container">
-      {images.map((image, key) => (
-        <ThumbnailListItem
-          key={`tn-${key}`}
-          id={key}
-          image={image}
-          onClickHandler={onClickHandler}
-        />
-      ))}
+      {images.map((image, key) => {
+        if (image === currentImage) {
+          return (
+            <ThumbnailListItem
+              key={`tn-${key}`}
+              id={key}
+              image={image}
+              classes="main-tn-current"
+              onClickHandler={onClickHandler}
+            />
+          );
+        }
+        return (
+          <ThumbnailListItem
+            key={`tn-${key}`}
+            id={key}
+            image={image}
+            classes="main-tn"
+            onClickHandler={onClickHandler}
+          />
+        );
+      })}
     </ul>
   );
 };

--- a/client/src/components/ThumbnailListItem.jsx
+++ b/client/src/components/ThumbnailListItem.jsx
@@ -4,11 +4,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ThumbnailListItem = (props) => {
-  const { image, id, onClickHandler } = props;
+  const {
+    image,
+    id,
+    onClickHandler,
+    classes,
+  } = props;
   const thumbId = `thumbnail-${id}`;
 
   return (
-    <li className="thumbnail-list-item round-corners">
+    <li className={`thumbnail-list-item round-corners ${classes}`}>
       <img
         id={thumbId}
         src={image.thumbnail}
@@ -23,6 +28,7 @@ ThumbnailListItem.propTypes = {
   image: PropTypes.objectOf(PropTypes.string).isRequired,
   onClickHandler: PropTypes.func.isRequired,
   id: PropTypes.number.isRequired,
+  classes: PropTypes.string.isRequired,
 };
 
 export default ThumbnailListItem;

--- a/public/styles.css
+++ b/public/styles.css
@@ -80,12 +80,11 @@
   justify-content: center;
 }
 
-
-
 .thumbnail-list-item img {
   object-fit: cover;
   height: 100%;
   opacity: .6;
+  transition: opacity 0.1s;
 }
 
 .thumbnail-list-item img:hover {
@@ -197,6 +196,10 @@
   margin: 0;
 }
 
+.modal-thumb-item {
+  box-sizing: border-box;
+}
+
 .thumb-lg {
   height: 228px;
   width: 228px;
@@ -215,6 +218,10 @@
 
 .thumb-r {
   margin-bottom: 12px;
+}
+
+.thumb-current {
+  border: 2px solid white;
 }
 
 /* ===== BUTTONS ===== */

--- a/public/styles.css
+++ b/public/styles.css
@@ -34,11 +34,22 @@
   position: relative;
   display: flex;
   margin: 0;
-  
 }
 
-.main-view-content img {
+.main-image {
+
   object-fit: fill;
+  width: auto;
+  height: 0;
+  visibility: hidden;
+  opacity: 0;
+  transition: visibility 0s, opacity 0.6s ease-in;
+}
+
+.main-image-visible {
+  height: auto;
+  visibility: visible;
+  opacity: 1;
 }
 
 /* ===== MAIN CAROUSEL ===== */

--- a/public/styles.css
+++ b/public/styles.css
@@ -80,9 +80,24 @@
   justify-content: center;
 }
 
+
+
 .thumbnail-list-item img {
   object-fit: cover;
   height: 100%;
+  opacity: .6;
+}
+
+.thumbnail-list-item img:hover {
+  opacity: 1;
+}
+
+.main-tn-current {
+  border: 2px solid black;
+}
+
+.main-tn-current img {
+  opacity: 1;
 }
 
 .thumbnail-scroll-up {
@@ -102,6 +117,8 @@
   width: 100%;
   height: 60px;
 }
+
+
 
 /* ===== MODAL ===== */
 


### PR DESCRIPTION
Fixed a bug that prevented clicking on the top item in the carousel and clicking on the bottom item in the carousel due to the overlays that provide the scroll effect on mouseover.

I ended up implementing a new on-click function for the overlays that briefly hides the overlay and then transmits the click to whatever element is underneath it.