### PR TITLE
Readme update, changes how productId is retrieved, fixes carousel display bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,28 +19,28 @@ To render the components on your page, insert a div with the id "gallery" into y
 
 If serving with a proxy, you'll need to proxy the routes for the API:
 
-  ## GET: ‘/api/images/:productId’ 
-    Used to get the details object for the productId containing the product’s id, product name, a boolean value indicating if the product is marked as a favorite, and an images property that contains a collection of image objects associated with the product.  Each image object in the collection will contain three url strings that link to a full, small, and thumbnail sized version of the image.  GET requests sent to this endpoint will return an object of the following format:
+## GET: ‘/api/images/:productId’ 
+Used to get the details object for the productId containing the product’s id, product name, a boolean value indicating if the product is marked as a favorite, and an images property that contains a collection of image objects associated with the product.  Each image object in the collection will contain three url strings that link to a full, small, and thumbnail sized version of the image.  GET requests sent to this endpoint will return an object of the following format:
 
-    ```sh
-    {
-      id: <number>,
-      name: <string>,
-      isFavorite: <boolean>
-      Images: [
-              {
-                  full: <string>,
-        small: <string>,
-        thumbnail: <string>
-              },
-              { … },
-              ...
+```sh
+{
+  id: <number>,
+  name: <string>,
+  isFavorite: <boolean>
+  Images: [
+            {
+              full: <string>,
+              small: <string>,
+              thumbnail: <string>
+            },
+            { … },
+            ...
           ]
-    }
-    ```
+}
+```
 
-  ## PATCH: ‘/api/favorite/:productId’
-    Used to favorite or unfavorite the product matching the productId parameter.  PATCH requests sent to this endpoint will toggle the isFavorite property of the product.  If successful, the request will return status 200.
+## PATCH: ‘/api/favorite/:productId’
+Used to favorite or unfavorite the product matching the productId parameter.  PATCH requests sent to this endpoint will toggle the isFavorite property of the product.  If successful, the request will return status 200.
 
 
 ## Requirements

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3,11 +3,15 @@ import ReactDOM from 'react-dom';
 import Gallery from './components/Gallery';
 import './styles.css';
 
-const App = () => (
-  <div>
-    <Gallery productId="2" />
-  </div>
-);
+const App = () => {
+  const productId = (window.location.pathname).substr(-3);
+
+  return (
+    <div>
+      <Gallery productId={productId} />
+    </div>
+  );
+};
 
 ReactDOM.render(<App />, document.getElementById('gallery'));
 

--- a/client/src/components/ThumbnailListItem.jsx
+++ b/client/src/components/ThumbnailListItem.jsx
@@ -16,6 +16,7 @@ const ThumbnailListItem = (props) => {
     <li className={`thumbnail-list-item round-corners ${classes}`}>
       <img
         id={thumbId}
+        className="thumbnail-list-img"
         src={image.thumbnail}
         alt="thumbnail"
         onClick={onClickHandler}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -65,12 +65,12 @@
 
 .thumbnail-list {
   flex-flow: column;
-  flex-wrap: wrap;
-  justify-content: flex-start;
+  height: 530px;
+  align-items: flex-end;
   box-sizing: border-box;
   list-style: none;
   scrollbar-width: none;
-  overflow: scroll;
+  overflow-y: scroll;
   -ms-overflow-style: none;
   padding: 0px;
   margin: 0px;
@@ -82,18 +82,22 @@
 
 .thumbnail-list-item {
   box-sizing: border-box;
-  display: flex;
+  flex-shrink: 0;
+  display: list-item;
+  overflow: hidden;
   width: 60px;
   height: 60px;
   margin-right: 6px;
   margin-bottom: 6px;
   padding: 0;
-  justify-content: center;
 }
 
-.thumbnail-list-item img {
-  object-fit: cover;
-  height: 100%;
+.thumbnail-list-image {
+  display: inline;
+  box-sizing: border-box;
+  max-height: 100%;
+  object-fit: fill;
+  margin: 0;
   opacity: .6;
   transition: opacity 0.1s;
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -64,9 +64,9 @@
 }
 
 .thumbnail-list {
-  flex-flow: row;
+  flex-flow: column;
   flex-wrap: wrap;
-  align-items: flex-start;
+  justify-content: flex-start;
   box-sizing: border-box;
   list-style: none;
   scrollbar-width: none;


### PR DESCRIPTION
Update to the README.md formatting to make it easier to read.

Changes how App.jsx is retrieving the productId.  It will now extract the last three digits from the page's path to derive a 3 digit productId from.

Resolved bug with the carousel spreading thumbnails evenly across the carousel if there weren't enough to fill it completely.